### PR TITLE
Fix #46 Support for volumes with 3 parts

### DIFF
--- a/internal/argsbuilder/argsbuilder.go
+++ b/internal/argsbuilder/argsbuilder.go
@@ -19,7 +19,7 @@ func (a *argsBuilder) SetEnv(env []string) ArgsBuilder {
 
 func (a *argsBuilder) SetVolumes(binds []string) ArgsBuilder {
 	for _, v := range binds {
-		if tokens := strings.Split(v, ":"); len(tokens) == 2 {
+		if tokens := strings.Split(v, ":"); len(tokens) == 2 || len(tokens) == 3 {
 			*a.commandArgs = append(*a.commandArgs, "-v", v)
 		}
 	}


### PR DESCRIPTION
Fix for issue #46, this is needed for selinux enabled distros.

This enables support for 2 and 3 parts volumes:
- 2 parts: `./local:/in-container`
- 3 parts, 3rd part being security options: `./local:/in-container:z`